### PR TITLE
recently added repositories are now stored in a html file so they can be downloaded and emailed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ archive.txt
 **/__pycache__/
 repositories.json
 archived.json
+recentlyAdded.html

--- a/repoarchivetool/api_interface.py
+++ b/repoarchivetool/api_interface.py
@@ -270,7 +270,8 @@ def get_organisation_repos(org: str, date: str, repo_type: str, gh: api_controll
                                 "type": repo["visibility"],
                                 "apiUrl": repo["url"],
                                 "lastCommitDate": str(last_update),
-                                "contributorsUrl": repo["contributors_url"]
+                                "contributorsUrl": repo["contributors_url"],
+                                "htmlUrl": repo["html_url"]
                             })
                     else:
                         return f"Error {response.status_code}: {response.json()["message"]} <br> Point of Failure: Getting Individual Repositories."

--- a/repoarchivetool/templates/manageRepositories.html
+++ b/repoarchivetool/templates/manageRepositories.html
@@ -201,6 +201,19 @@
 		</span>
 	</button>
 
+	<br>
+
+	<a href="/download_recently_added" role="button"
+		class="ons-btn ons-btn--download ons-btn--small ons-btn--secondary ons-btn--link ons-js-submit-btn ons-u-mt-s">
+		<span class="ons-btn__inner"><svg class="ons-icon ons-u-mr-xs" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"
+				focusable="false" fill="currentColor" role="img" title="ons-icon-download">
+				<path
+					d="M5.6 9a.48.48 0 0 0 .7 0l3-3.2a.48.48 0 0 0 0-.7C9.3 5 9.2 5 9 5H7.5V.5A.47.47 0 0 0 7 0H5a.47.47 0 0 0-.5.5V5H3a.47.47 0 0 0-.5.5.37.37 0 0 0 .1.3Z" />
+				<path
+					d="M11.5 9H11a.47.47 0 0 0-.5.5v1h-9v-1A.47.47 0 0 0 1 9H.5a.47.47 0 0 0-.5.5v2a.47.47 0 0 0 .5.5h11a.47.47 0 0 0 .5-.5v-2a.47.47 0 0 0-.5-.5Z" />
+			</svg><span class="ons-btn__text">Download Recently Added Repositories</span></span>
+	</a>
+
 {% endif %}
 
 {% endblock %}

--- a/repoarchivetool/templates/success.html
+++ b/repoarchivetool/templates/success.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+
+{% block pagetitle %}Repository Archive Tool - Success{% endblock %}
+
+{% block body %}
+    <h1 class="ons-u-mt-l">Repository Successfully Marked as Exempt</h1>
+    <p>The Repository has been successfully marked as exempt and will not be archived until the exempt date has passed. Please feel free to close this tab.</p>
+{% endblock %}


### PR DESCRIPTION
- Writes repository name and html url to recentlyAdded.html when /find_repositories is run
- This file can be downloaded using a button in /manage_repositories
- This file can then be emailed out as requested