### PR TITLE
Bug: check_file_integrity() needs to run when local files are out dated by S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ It is expected you have these tools installed before progressing further.
 
 4. Get the repo-archive-github.pem file and copy to the source code root directory (see "Getting a .pem file" below).
 
-5. When running the project locally, you need to edit `get_bucket_content()` and `update_bucket_content()` within `storage_interface.py`.
+5. When running the project locally, you need to edit `get_s3_client()` within `storage_interface.py`.
 
 When creating an instance of `boto3.session()`, you must pass which AWS credential profile to use, as found in `~/.aws/credentials`.
 

--- a/repoarchivetool/app.py
+++ b/repoarchivetool/app.py
@@ -31,9 +31,8 @@ def check_file_integrity(files: List[str], directory: str = "./"):
     for file in files:
         file_path = os.path.join(directory, file)
 
-        if not os.path.isfile(file_path):
+        if (not os.path.isfile(file_path)) or storage_interface.has_file_changed("github-audit-tool", f"repo-archive/{file}", file):
             storage_interface.get_bucket_content(file)
-
 
 def update_token():
     """

--- a/repoarchivetool/storage_interface.py
+++ b/repoarchivetool/storage_interface.py
@@ -1,6 +1,46 @@
 import json
 import boto3
 from botocore.exceptions import ClientError
+import os
+import pprint
+
+def get_s3_client():
+    """
+        Returns an S3 Client
+
+        ==========
+
+        Returns:
+            S3 Client
+    """
+    session = boto3.Session()
+    s3 = session.client("s3")
+
+    return s3
+
+def has_file_changed(bucket: str, key: str, filename: str) -> bool:
+    """
+        Checks if a file in an S3 Bucket has changed
+
+        ==========
+
+        Args:
+            bucket (str): The name of the bucket
+            key (str): The key of the file
+            filename (str): The name of the file to compare
+
+        Returns:
+            bool
+    """
+    
+    s3 = get_s3_client()
+
+    obj = s3.get_object(Bucket=bucket, Key=key)
+
+    last_modified = int(obj["LastModified"].strftime("%s"))
+    content_length = obj["ContentLength"]
+
+    return last_modified != os.path.getmtime(filename) or content_length != os.path.getsize(filename)
 
 def get_bucket_content(filename: str) -> bool | ClientError:
     """
@@ -15,8 +55,7 @@ def get_bucket_content(filename: str) -> bool | ClientError:
             Bool or ClientError
     """
 
-    session = boto3.Session()
-    s3 = session.client("s3")
+    s3 = get_s3_client()
 
     try:
         s3.download_file("github-audit-tool", f"repo-archive/{filename}", filename)
@@ -37,8 +76,7 @@ def update_bucket_content(filename: str) -> bool | ClientError:
             Bool or ClientError
     """
 
-    session = boto3.Session()
-    s3 = session.client("s3")
+    s3 = get_s3_client()
 
     try:
         response = s3.upload_file(filename, "github-audit-tool", f"repo-archive/{filename}")


### PR DESCRIPTION
Before this PR, the app would only download files from S3 if they didn't already exist locally. This meant that if a change was made from another container, the local files could desynchronise from S3.

This PR make check_file_integrity() download files from S3 if either:
-  The files don't exist locally
- The S3 and local files do not have the same last modified date
- The S3 and local files do not have the same size

I have also added a get_s3_client() function to make adding a profile when running outside of a container easier (you only have to make the change in one place)